### PR TITLE
fix: filter for new rating system

### DIFF
--- a/internal/stash/filter/scenefilter.go
+++ b/internal/stash/filter/scenefilter.go
@@ -129,7 +129,7 @@ func setSceneFilterCriterion(criterion jsonCriterion, sceneFilter *gql.SceneFilt
 		}
 
 	//IntCriterionInput
-	case "rating":
+	case "rating", "rating100":
 		sceneFilter.Rating, err = criterion.asIntCriterionInput()
 		if err != nil {
 			return fmt.Errorf("AsIntCriterionInput: %w", err)


### PR DESCRIPTION
New ratings are stored under "rating100". Old field is deprecated:
https://github.com/stashapp/stash/blob/4daf0a14a2e4931d0f10e937cc3d88e31407e278/graphql/schema/types/filters.graphql#L106