### PR TITLE
feat: support new rating100 field with updates

### DIFF
--- a/internal/api/heresphere/scan.go
+++ b/internal/api/heresphere/scan.go
@@ -3,11 +3,12 @@ package heresphere
 import (
 	"context"
 	"fmt"
-	"github.com/Khan/genqlient/graphql"
 	"stash-vr/internal/sections"
 	"stash-vr/internal/stash/gql"
 	"stash-vr/internal/util"
 	"strconv"
+
+	"github.com/Khan/genqlient/graphql"
 )
 
 type scanDoc struct {
@@ -52,7 +53,7 @@ func buildScan(ctx context.Context, client graphql.Client, baseUrl string) (scan
 				DateReleased: part.Date,
 				DateAdded:    part.Created_at.Format("2006-01-02"),
 				Duration:     part.Files[0].Duration,
-				Rating:       float32(part.Rating),
+				Rating:       float32(part.Rating100) / 20.0,
 				Favorites:    part.O_counter,
 				IsFavorite:   ContainsFavoriteTag(part.TagPartsArray),
 				Tags:         getTags(part.SceneScanParts),

--- a/internal/api/heresphere/sync.go
+++ b/internal/api/heresphere/sync.go
@@ -2,14 +2,14 @@ package heresphere
 
 import (
 	"context"
-	"github.com/Khan/genqlient/graphql"
-	"github.com/rs/zerolog/log"
-	"math"
 	"stash-vr/internal/api/internal"
 	"stash-vr/internal/config"
 	"stash-vr/internal/stash"
 	"stash-vr/internal/stash/gql"
 	"strings"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/rs/zerolog/log"
 )
 
 type updateVideoData struct {
@@ -107,14 +107,7 @@ func toggleOrganized(ctx context.Context, client graphql.Client, sceneId string)
 }
 
 func updateRating(ctx context.Context, client graphql.Client, sceneId string, rating float32) {
-	var newRating int
-	if rating == 0.5 {
-		//special case to set zero rating
-		newRating = 0
-	} else {
-		newRating = int(math.Ceil(float64(rating)))
-	}
-
+	var newRating int = int(rating*20 + 0.5)
 	_, err := gql.SceneUpdateRating(ctx, client, sceneId, newRating)
 	if err != nil {
 		log.Ctx(ctx).Warn().Err(err).Int("rating", newRating).Msg("Failed to update rating")

--- a/internal/api/heresphere/tag.go
+++ b/internal/api/heresphere/tag.go
@@ -82,7 +82,7 @@ func getPerformers(s gql.SceneScanParts) []tag {
 	for i, p := range s.Performers {
 		tags[i] = tag{
 			Name:   internal.LegendPerformer.Full + seperator + p.Name,
-			Rating: float32(p.Rating),
+			Rating: float32(p.Rating100) / 20.0,
 		}
 	}
 	return tags
@@ -107,7 +107,7 @@ func getStudio(s gql.SceneScanParts) []tag {
 	}
 	return []tag{{
 		Name:   internal.LegendStudio.Full + seperator + s.Studio.Name,
-		Rating: float32(s.Studio.Rating),
+		Rating: float32(s.Studio.Rating100) / 20.0,
 	}}
 }
 

--- a/internal/api/heresphere/videodata.go
+++ b/internal/api/heresphere/videodata.go
@@ -3,11 +3,12 @@ package heresphere
 import (
 	"context"
 	"fmt"
-	"github.com/Khan/genqlient/graphql"
 	"stash-vr/internal/api/heatmap"
 	"stash-vr/internal/config"
 	"stash-vr/internal/stash"
 	"stash-vr/internal/stash/gql"
+
+	"github.com/Khan/genqlient/graphql"
 )
 
 type videoData struct {
@@ -87,7 +88,7 @@ func buildVideoData(ctx context.Context, client graphql.Client, baseUrl string, 
 		DateReleased:   s.Date,
 		DateAdded:      s.Created_at.Format("2006-01-02"),
 		Duration:       s.SceneScanParts.Files[0].Duration * 1000,
-		Rating:         float32(s.Rating),
+		Rating:         float32(s.Rating100) / 20.0,
 		Favorites:      s.O_counter,
 		WriteFavorite:  true,
 		WriteRating:    true,

--- a/internal/stash/gql/mutation.graphql
+++ b/internal/stash/gql/mutation.graphql
@@ -1,7 +1,7 @@
 mutation SceneUpdateRating($id: ID!, $rating: Int) {
     sceneUpdate(input: {
         id: $id,
-        rating: $rating
+        rating100: $rating
     }){id}
 }
 

--- a/internal/stash/gql/query.graphql
+++ b/internal/stash/gql/query.graphql
@@ -148,13 +148,13 @@ fragment SceneFullParts on Scene{
 }
 
 fragment SceneScanParts on Scene{
-    id, title, rating, created_at, date
+    id, title, rating100, created_at, date
     files{
         basename, duration
     }
     ...TagPartsArray
     studio{
-        id, name, rating
+        id, name, rating100
     },
     scene_markers {
         id, seconds, title, primary_tag {
@@ -162,7 +162,7 @@ fragment SceneScanParts on Scene{
         }
     },
     performers {
-        id, name, rating
+        id, name, rating100
     },
     movies {
         scene_index,

--- a/internal/stash/gql/schema/types/config.graphql
+++ b/internal/stash/gql/schema/types/config.graphql
@@ -264,6 +264,10 @@ input ConfigInterfaceInput {
   css: String
   cssEnabled: Boolean
 
+  """Custom Javascript"""
+  javascript: String
+  javascriptEnabled: Boolean
+
   """Custom Locales"""
   customLocales: String
   customLocalesEnabled: Boolean
@@ -329,6 +333,10 @@ type ConfigInterfaceResult {
   """Custom CSS"""
   css: String
   cssEnabled: Boolean
+
+  """Custom Javascript"""
+  javascript: String
+  javascriptEnabled: Boolean
 
   """Custom Locales"""
   customLocales: String

--- a/internal/stash/gql/schema/types/filters.graphql
+++ b/internal/stash/gql/schema/types/filters.graphql
@@ -39,6 +39,14 @@ input PHashDuplicationCriterionInput {
   distance: Int
 }
 
+input StashIDCriterionInput {
+  """If present, this value is treated as a predicate.
+  That is, it will filter based on stash_ids with the matching endpoint"""
+  endpoint: String
+  stash_id: String
+  modifier: CriterionModifier!
+}
+
 input PerformerFilterType {
   AND: PerformerFilterType
   OR: PerformerFilterType
@@ -60,7 +68,9 @@ input PerformerFilterType {
   """Filter by eye color"""
   eye_color: StringCriterionInput
   """Filter by height"""
-  height: StringCriterionInput
+  height: StringCriterionInput @deprecated(reason: "Use height_cm instead") 
+  """Filter by height in cm""" 
+  height_cm: IntCriterionInput
   """Filter by measurements"""
   measurements: StringCriterionInput
   """Filter by fake tits value"""
@@ -88,9 +98,13 @@ input PerformerFilterType {
   """Filter by gallery count"""
   gallery_count: IntCriterionInput
   """Filter by StashID"""
-  stash_id: StringCriterionInput
+  stash_id: StringCriterionInput @deprecated(reason: "Use stash_id_endpoint instead") 
+  """Filter by StashID"""
+  stash_id_endpoint: StashIDCriterionInput
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter by url"""
   url: StringCriterionInput
   """Filter by hair color"""
@@ -103,6 +117,14 @@ input PerformerFilterType {
   studios: HierarchicalMultiCriterionInput
   """Filter by autotag ignore value"""
   ignore_auto_tag: Boolean
+  """Filter by birthdate"""
+  birthdate: DateCriterionInput
+  """Filter by death date"""
+  death_date: DateCriterionInput
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 input SceneMarkerFilterType {
@@ -114,6 +136,16 @@ input SceneMarkerFilterType {
   scene_tags: HierarchicalMultiCriterionInput
   """Filter to only include scene markers with these performers"""
   performers: MultiCriterionInput
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
+  """Filter by scene date"""
+  scene_date: DateCriterionInput
+  """Filter by cscene reation time"""
+  scene_created_at: TimestampCriterionInput
+  """Filter by lscene ast update time"""
+  scene_updated_at: TimestampCriterionInput
 }
 
 input SceneFilterType {
@@ -121,8 +153,11 @@ input SceneFilterType {
   OR: SceneFilterType
   NOT: SceneFilterType
 
+  id: IntCriterionInput
   title: StringCriterionInput
+  code: StringCriterionInput
   details: StringCriterionInput
+  director: StringCriterionInput
 
   """Filter by file oshash"""
   oshash: StringCriterionInput
@@ -135,7 +170,9 @@ input SceneFilterType {
   """Filter by file count"""
   file_count: IntCriterionInput
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter by organized"""
   organized: Boolean
   """Filter by o-counter"""
@@ -169,7 +206,9 @@ input SceneFilterType {
   """Filter by performer count"""
   performer_count: IntCriterionInput
   """Filter by StashID"""
-  stash_id: StringCriterionInput
+  stash_id: StringCriterionInput @deprecated(reason: "Use stash_id_endpoint instead") 
+  """Filter by StashID"""
+  stash_id_endpoint: StashIDCriterionInput
   """Filter by url"""
   url: StringCriterionInput
   """Filter by interactive"""
@@ -178,6 +217,18 @@ input SceneFilterType {
   interactive_speed: IntCriterionInput
   """Filter by captions"""
   captions: StringCriterionInput
+  """Filter by resume time"""
+  resume_time: IntCriterionInput
+  """Filter by play count"""
+  play_count: IntCriterionInput
+  """Filter by play duration (in seconds)"""
+  play_duration: IntCriterionInput
+  """Filter by date"""
+  date: DateCriterionInput
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 input MovieFilterType {
@@ -189,7 +240,9 @@ input MovieFilterType {
   """Filter by duration (in seconds)"""
   duration: IntCriterionInput
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter to only include movies with this studio"""
   studios: HierarchicalMultiCriterionInput
   """Filter to only include movies missing this property"""
@@ -198,6 +251,12 @@ input MovieFilterType {
   url: StringCriterionInput
   """Filter to only include movies where performer appears in a scene"""
   performers: MultiCriterionInput
+  """Filter by date"""
+  date: DateCriterionInput
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 input StudioFilterType {
@@ -210,11 +269,15 @@ input StudioFilterType {
   """Filter to only include studios with this parent studio"""
   parents: MultiCriterionInput
   """Filter by StashID"""
-  stash_id: StringCriterionInput
+  stash_id: StringCriterionInput @deprecated(reason: "Use stash_id_endpoint instead") 
+  """Filter by StashID"""
+  stash_id_endpoint: StashIDCriterionInput
   """Filter to only include studios missing this property"""
   is_missing: String
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter by scene count"""
   scene_count: IntCriterionInput
   """Filter by image count"""
@@ -227,6 +290,10 @@ input StudioFilterType {
   aliases: StringCriterionInput
   """Filter by autotag ignore value"""
   ignore_auto_tag: Boolean
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 input GalleryFilterType {
@@ -234,6 +301,7 @@ input GalleryFilterType {
   OR: GalleryFilterType
   NOT: GalleryFilterType
 
+  id: IntCriterionInput
   title: StringCriterionInput
   details: StringCriterionInput
 
@@ -248,7 +316,9 @@ input GalleryFilterType {
   """Filter to include/exclude galleries that were created from zip"""
   is_zip: Boolean
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter by organized"""
   organized: Boolean
   """Filter by average image resolution"""
@@ -273,6 +343,12 @@ input GalleryFilterType {
   image_count: IntCriterionInput
   """Filter by url"""
   url: StringCriterionInput
+  """Filter by date"""
+  date: DateCriterionInput
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 input TagFilterType {
@@ -285,6 +361,9 @@ input TagFilterType {
 
   """Filter by tag aliases"""
   aliases: StringCriterionInput
+
+  """Filter by tag description"""
+  description: StringCriterionInput
 
   """Filter to only include tags missing this property"""
   is_missing: String
@@ -318,6 +397,12 @@ input TagFilterType {
 
   """Filter by autotag ignore value"""
   ignore_auto_tag: Boolean
+
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 input ImageFilterType {
@@ -327,6 +412,8 @@ input ImageFilterType {
 
   title: StringCriterionInput
 
+  """ Filter by image id"""
+  id: IntCriterionInput
   """Filter by file checksum"""
   checksum: StringCriterionInput
   """Filter by path"""
@@ -334,7 +421,9 @@ input ImageFilterType {
   """Filter by file count"""
   file_count: IntCriterionInput
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter by organized"""
   organized: Boolean
   """Filter by o-counter"""
@@ -359,6 +448,10 @@ input ImageFilterType {
   performer_favorite: Boolean
   """Filter to only include images with these galleries"""
   galleries: MultiCriterionInput
+  """Filter by creation time"""
+  created_at: TimestampCriterionInput
+  """Filter by last update time"""
+  updated_at: TimestampCriterionInput
 }
 
 enum CriterionModifier {
@@ -413,6 +506,18 @@ input HierarchicalMultiCriterionInput {
   value: [ID!]
   modifier: CriterionModifier!
   depth: Int
+}
+
+input DateCriterionInput {
+  value: String!
+  value2: String
+  modifier: CriterionModifier!
+}
+
+input TimestampCriterionInput {
+  value: String!
+  value2: String
+  modifier: CriterionModifier!
 }
 
 enum FilterMode {

--- a/internal/stash/gql/schema/types/gallery.graphql
+++ b/internal/stash/gql/schema/types/gallery.graphql
@@ -7,7 +7,10 @@ type Gallery {
   url: String
   date: String
   details: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean!
   created_at: Time!
   updated_at: Time!
@@ -23,7 +26,7 @@ type Gallery {
   performers: [Performer!]!
 
   """The images in the gallery"""
-  images: [Image!]! # Resolver
+  images: [Image!]! @deprecated(reason: "Use findImages")
   cover: Image
 }
 
@@ -32,7 +35,10 @@ input GalleryCreateInput {
   url: String
   date: String
   details: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   scene_ids: [ID!]
   studio_id: ID
@@ -47,7 +53,10 @@ input GalleryUpdateInput {
   url: String
   date: String
   details: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   scene_ids: [ID!]
   studio_id: ID
@@ -63,7 +72,10 @@ input BulkGalleryUpdateInput {
   url: String
   date: String
   details: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   scene_ids: BulkUpdateIds
   studio_id: ID

--- a/internal/stash/gql/schema/types/image.graphql
+++ b/internal/stash/gql/schema/types/image.graphql
@@ -2,7 +2,10 @@ type Image {
   id: ID!
   checksum: String @deprecated(reason: "Use files.fingerprints")
   title: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   o_counter: Int
   organized: Boolean!
   path: String! @deprecated(reason: "Use files.path")
@@ -37,7 +40,10 @@ input ImageUpdateInput {
   clientMutationId: String
   id: ID!
   title: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   
   studio_id: ID
@@ -52,7 +58,10 @@ input BulkImageUpdateInput {
   clientMutationId: String
   ids: [ID!]
   title: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   
   studio_id: ID

--- a/internal/stash/gql/schema/types/movie.graphql
+++ b/internal/stash/gql/schema/types/movie.graphql
@@ -6,7 +6,10 @@ type Movie {
   """Duration in seconds"""
   duration: Int
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   studio: Studio
   director: String
   synopsis: String
@@ -26,7 +29,10 @@ input MovieCreateInput {
   """Duration in seconds"""
   duration: Int
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   studio_id: ID
   director: String
   synopsis: String
@@ -43,7 +49,10 @@ input MovieUpdateInput {
   aliases: String
   duration: Int
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   studio_id: ID
   director: String
   synopsis: String
@@ -57,7 +66,10 @@ input MovieUpdateInput {
 input BulkMovieUpdateInput {
   clientMutationId: String
   ids: [ID!]
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   studio_id: ID
   director: String
 }

--- a/internal/stash/gql/schema/types/performer.graphql
+++ b/internal/stash/gql/schema/types/performer.graphql
@@ -19,7 +19,8 @@ type Performer {
   ethnicity: String
   country: String
   eye_color: String
-  height: String
+  height: String @deprecated(reason: "Use height_cm")
+  height_cm: Int
   measurements: String
   fake_tits: String
   career_length: String
@@ -36,7 +37,10 @@ type Performer {
   gallery_count: Int # Resolver
   scenes: [Scene!]!
   stash_ids: [StashID!]!
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   death_date: String
   hair_color: String
@@ -55,7 +59,9 @@ input PerformerCreateInput {
   ethnicity: String
   country: String
   eye_color: String
-  height: String
+  # height must be parsable into an integer
+  height: String @deprecated(reason: "Use height_cm")
+  height_cm: Int
   measurements: String
   fake_tits: String
   career_length: String
@@ -69,7 +75,10 @@ input PerformerCreateInput {
   """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   death_date: String
   hair_color: String
@@ -86,7 +95,9 @@ input PerformerUpdateInput {
   ethnicity: String
   country: String
   eye_color: String
-  height: String
+  # height must be parsable into an integer
+  height: String @deprecated(reason: "Use height_cm")
+  height_cm: Int
   measurements: String
   fake_tits: String
   career_length: String
@@ -100,7 +111,10 @@ input PerformerUpdateInput {
   """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   death_date: String
   hair_color: String
@@ -117,7 +131,9 @@ input BulkPerformerUpdateInput {
   ethnicity: String
   country: String
   eye_color: String
-  height: String
+  # height must be parsable into an integer
+  height: String @deprecated(reason: "Use height_cm")
+  height_cm: Int
   measurements: String
   fake_tits: String
   career_length: String
@@ -128,7 +144,10 @@ input BulkPerformerUpdateInput {
   instagram: String
   favorite: Boolean
   tag_ids: BulkUpdateIds
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   death_date: String
   hair_color: String

--- a/internal/stash/gql/schema/types/scene.graphql
+++ b/internal/stash/gql/schema/types/scene.graphql
@@ -15,7 +15,7 @@ type ScenePathsType {
   stream: String # Resolver
   webp: String # Resolver
   vtt: String # Resolver
-  chapters_vtt: String # Resolver
+  chapters_vtt: String @deprecated
   sprite: String # Resolver
   funscript: String # Resolver
   interactive_heatmap: String # Resolver
@@ -37,10 +37,15 @@ type Scene {
   checksum: String @deprecated(reason: "Use files.fingerprints")
   oshash: String @deprecated(reason: "Use files.fingerprints")
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean!
   o_counter: Int
   path: String! @deprecated(reason: "Use files.path")
@@ -51,6 +56,14 @@ type Scene {
   created_at: Time!
   updated_at: Time!
   file_mod_time: Time
+  """The last time play count was updated"""
+  last_played_at: Time
+  """The time index a scene was left at"""
+  resume_time: Float
+  """The total time a scene has spent playing"""
+  play_duration: Float
+  """The number ot times a scene has been played"""
+  play_count: Int
 
   file: SceneFileType! @deprecated(reason: "Use files")
   files: [VideoFile!]!
@@ -73,14 +86,17 @@ input SceneMovieInput {
   scene_index: Int
 }
 
-input SceneUpdateInput {
-  clientMutationId: String
-  id: ID!
+input SceneCreateInput {
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   studio_id: ID
   gallery_ids: [ID!]
@@ -90,6 +106,42 @@ input SceneUpdateInput {
   """This should be a URL or a base64 encoded data URL"""
   cover_image: String
   stash_ids: [StashIDInput!]
+
+  """The first id will be assigned as primary. Files will be reassigned from
+  existing scenes if applicable. Files must not already be primary for another scene"""
+  file_ids: [ID!]
+}
+
+input SceneUpdateInput {
+  clientMutationId: String
+  id: ID!
+  title: String
+  code: String
+  details: String
+  director: String
+  url: String
+  date: String
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
+  o_counter: Int
+  organized: Boolean
+  studio_id: ID
+  gallery_ids: [ID!]
+  performer_ids: [ID!]
+  movies: [SceneMovieInput!]
+  tag_ids: [ID!]
+  """This should be a URL or a base64 encoded data URL"""
+  cover_image: String
+  stash_ids: [StashIDInput!]
+
+  """The time index a scene was left at"""
+  resume_time: Float
+  """The total time a scene has spent playing"""
+  play_duration: Float
+  """The number ot times a scene has been played"""
+  play_count: Int
 
   primary_file_id: ID
 }
@@ -109,10 +161,15 @@ input BulkSceneUpdateInput {
   clientMutationId: String
   ids: [ID!]
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   studio_id: ID
   gallery_ids: BulkUpdateIds
@@ -157,10 +214,15 @@ type SceneMovieID {
 type SceneParserResult {
   scene: Scene!
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   studio_id: ID
   gallery_ids: [ID!]
   performer_ids: [ID!]
@@ -182,4 +244,18 @@ type SceneStreamEndpoint {
   url: String!
   mime_type: String
   label: String
+}
+
+input AssignSceneFileInput {
+  scene_id: ID!
+  file_id: ID!
+}
+
+input SceneMergeInput {
+  """If destination scene has no files, then the primary file of the
+  first source scene will be assigned as primary"""
+  source: [ID!]!
+  destination: ID!
+  # values defined here will override values in the destination
+  values: SceneUpdateInput
 }

--- a/internal/stash/gql/schema/types/scraper.graphql
+++ b/internal/stash/gql/schema/types/scraper.graphql
@@ -61,7 +61,9 @@ type ScrapedTag {
 
 type ScrapedScene {
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
 
@@ -82,7 +84,9 @@ type ScrapedScene {
 
 input ScrapedSceneInput {
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
 

--- a/internal/stash/gql/schema/types/studio.graphql
+++ b/internal/stash/gql/schema/types/studio.graphql
@@ -13,7 +13,10 @@ type Studio {
   image_count: Int # Resolver
   gallery_count: Int # Resolver
   stash_ids: [StashID!]!
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   created_at: Time!
   updated_at: Time!
@@ -28,7 +31,10 @@ input StudioCreateInput {
   """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   aliases: [String!]
   ignore_auto_tag: Boolean
@@ -42,7 +48,10 @@ input StudioUpdateInput {
   """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   details: String
   aliases: [String!]
   ignore_auto_tag: Boolean


### PR DESCRIPTION
Update stash graphql schema to 0.18 and move to new rating100.
This removes special case for 0.5 as this can be a valid rating now.
Closes #5 