### PR TITLE
feat: add subtitle support

### DIFF
--- a/internal/api/deovr/videodata.go
+++ b/internal/api/deovr/videodata.go
@@ -25,7 +25,7 @@ type videoData struct {
 	VideoPreview   string `json:"videoPreview,omitempty"`
 	ThumbnailUrl   string `json:"thumbnailUrl"`
 
-	Subtitles  []subtitle `json:"subtitles"`
+	Subtitles []subtitle `json:"subtitles"`
 
 	TimeStamps []timeStamp `json:"timeStamps,omitempty"`
 
@@ -38,8 +38,8 @@ type timeStamp struct {
 }
 
 type subtitle struct {
-	Title    string `json:"title"`
-	Url      string `json:"url"`
+	Title string `json:"title"`
+	Url   string `json:"url"`
 }
 
 type encoding struct {
@@ -100,7 +100,7 @@ func setSubtitles(s gql.SceneFullParts, videoData *videoData) {
 		for _, c := range s.Captions {
 			videoData.Subtitles = append(videoData.Subtitles, subtitle{
 				Title: fmt.Sprintf(".%s.%s", c.Language_code, c.Caption_type),
-				Url: stash.ApiKeyed(fmt.Sprintf("%s?lang=%s&type=%s", s.Paths.Caption, c.Language_code, c.Caption_type)),
+				Url:   stash.ApiKeyed(fmt.Sprintf("%s?lang=%s&type=%s", s.Paths.Caption, c.Language_code, c.Caption_type)),
 			})
 		}
 	}

--- a/internal/api/heresphere/videodata.go
+++ b/internal/api/heresphere/videodata.go
@@ -159,9 +159,9 @@ func setSubtitles(s gql.SceneFullParts, videoData *videoData) {
 	if s.Captions != nil {
 		for _, c := range s.Captions {
 			videoData.Subtitles = append(videoData.Subtitles, subtitle{
-				Name: fmt.Sprintf(".%s.%s", c.Language_code, c.Caption_type),
+				Name:     fmt.Sprintf(".%s.%s", c.Language_code, c.Caption_type),
 				Language: c.Language_code,
-				Url: stash.ApiKeyed(fmt.Sprintf("%s?lang=%s&type=%s", s.Paths.Caption, c.Language_code, c.Caption_type)),
+				Url:      stash.ApiKeyed(fmt.Sprintf("%s?lang=%s&type=%s", s.Paths.Caption, c.Language_code, c.Caption_type)),
 			})
 		}
 	}

--- a/internal/stash/gql/documents/query.graphql
+++ b/internal/stash/gql/documents/query.graphql
@@ -149,13 +149,16 @@ fragment ScenePreviewParts on Scene{
 fragment SceneFullParts on Scene{
     ...SceneScanParts
     details,
-    paths{screenshot, preview},
+    paths{screenshot, preview, caption},
     ...ScriptParts
     ...StreamsParts
 }
 
 fragment SceneScanParts on Scene{
     id, title, rating100, created_at, date
+    captions{
+        caption_type, language_code
+    }
     files{
         basename, duration
     }


### PR DESCRIPTION
Tested with latest Heresphere (0.10.2) and DeoVR (13.19.1687) on Quest 2.

To add subtitles in stash name the subtitle file same as the video file except with .srt extension or .en.srt, .de.srt etc for different languages, then rescan stash library so it finds the file, if there's no language code in the filename it shows up as "00" in the API. 

There's btw some idiosyncrasies relating to subtitles in stash and the players:

**stash**: /caption API reformats all subtitle files into webvtt which looks almost the same as subrip/.srt but if you test samba shared subtitle vs subtitle over API it might work differently because of that reformatting (there was also a "bug" in previous heresphere version that didn't render subtitles because the millisecond separator is different between those formats)

**heresphere**: doesn't have a language selection so if stash has multiple subtitles for one video it picks the first one in the json array which appear to be alphabetically sorted by the language code. when heresphere detects that video has a subtitle the CC icon next to timeline turns purple but I found out that if the Name property in stash-vr json reply doesn't end with ".srt" it refused to render subtitles (probably because it uses it to decide between different subtitle parsers).

**deovr**: also picks the alphabetically first subtitle although it does appear to have a dropdown in the video menu to change the active subtitle it didn't seem to work for me but I think most users only really care about having one subtitle so not sure if it's even worth reporting/investigating.

Resolves #37 