### PR TITLE
add HSP support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: "3.0"
 services:
   stash-vr:
     image: ofl0w/stash-vr:latest
+    #build: .
     container_name: stash-vr
     restart: unless-stopped
     ports:
       - "9666:9666"
     environment:
       STASH_GRAPHQL_URL: "http://localhost:9999/graphql"
+      HSP_DIR: /hsp/
       #STASH_API_KEY: "xxx"
       #FAVORITE_TAG: "FAVORITE"
 
@@ -25,3 +27,5 @@ services:
       #LOG_LEVEL: "debug"
 
       #FORCE_HTTPS: "true"
+    volumes:
+     - ./hsp:/hsp/

--- a/internal/api/heresphere/http.go
+++ b/internal/api/heresphere/http.go
@@ -93,6 +93,16 @@ func (h *httpHandler) videoDataHandler(w http.ResponseWriter, req *http.Request)
 	}
 }
 
+func (h *httpHandler) videoHspHandler(hspDir string) http.HandlerFunc {
+	filesDir := http.Dir(hspDir)
+	return func(w http.ResponseWriter, r *http.Request) {
+		sceneId := chi.URLParam(r, "videoId")
+		r.URL.Path = sceneId + ".hsp"
+		fs := http.FileServer(filesDir)
+		fs.ServeHTTP(w, r)
+	}
+}
+
 func (h *httpHandler) eventsHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 

--- a/internal/api/heresphere/router.go
+++ b/internal/api/heresphere/router.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"stash-vr/internal/api/internal"
+	"stash-vr/internal/config"
 )
 
 func Router(client graphql.Client) http.Handler {
@@ -15,6 +16,9 @@ func Router(client graphql.Client) http.Handler {
 	r.Use(middleware.SetHeader("HereSphere-JSON-Version", "1"))
 	r.Post("/", internal.LogRoute("index", httpHandler.indexHandler))
 	r.Post("/scan", internal.LogRoute("scan", httpHandler.scanHandler))
+	if config.Get().HspDir != "" {
+		r.Get("/{videoId}/hsp", internal.LogRoute("hsp", httpHandler.videoHspHandler(config.Get().HspDir)).ServeHTTP)
+	}
 	r.Handle("/{videoId}", internal.LogRoute("videoData", internal.LogVideoId(httpHandler.videoDataHandler)))
 	r.Post("/events", internal.LogRoute("events", httpHandler.eventsHandler))
 	return r
@@ -22,4 +26,8 @@ func Router(client graphql.Client) http.Handler {
 
 func getVideoDataUrl(baseUrl string, id string) string {
 	return baseUrl + "/heresphere/" + url.QueryEscape(id)
+}
+
+func getHspDataUrl(baseUrl string, id string) string {
+	return baseUrl + "/heresphere/" + url.QueryEscape(id) + "/hsp"
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ const (
 	envKeyStashApiKey      = "STASH_API_KEY"
 	envKeyFavoriteTag      = "FAVORITE_TAG"
 	envKeyFilters          = "FILTERS"
+	envKeyHspDir           = "HSP_DIR"
 	envKeyLogLevel         = "LOG_LEVEL"
 	envKeyDisableLogColor  = "DISABLE_LOG_COLOR"
 	envKeyDisableRedact    = "DISABLE_REDACT"
@@ -30,6 +31,7 @@ type Application struct {
 	StashApiKey          string
 	FavoriteTag          string
 	Filters              string
+	HspDir               string
 	IsSyncMarkersAllowed bool
 	LogLevel             string
 	DisableLogColor      bool
@@ -58,6 +60,9 @@ func Init() {
 
 	pflag.String(envKeyFilters, "", "Narrow the selection of filters to show. Either 'frontpage' or a comma seperated list of filter ids")
 	_ = viper.BindPFlag(envKeyFilters, pflag.Lookup(envKeyFilters))
+
+	pflag.String(envKeyHspDir, "", "Directory for Heresphere HSP files")
+	_ = viper.BindPFlag(envKeyHspDir, pflag.Lookup(envKeyHspDir))
 
 	pflag.Bool(envKeyAllowSyncMarkers, false, "Enable sync of Marker from HereSphere")
 	_ = viper.BindPFlag(envKeyAllowSyncMarkers, pflag.Lookup(envKeyAllowSyncMarkers))
@@ -103,6 +108,7 @@ func Init() {
 	cfg.StashApiKey = viper.GetString(envKeyStashApiKey)
 	cfg.FavoriteTag = viper.GetString(envKeyFavoriteTag)
 	cfg.Filters = viper.GetString(envKeyFilters)
+	cfg.HspDir = viper.GetString(envKeyHspDir)
 	cfg.IsSyncMarkersAllowed = viper.GetBool(envKeyAllowSyncMarkers)
 	cfg.LogLevel = strings.ToLower(viper.GetString(envKeyLogLevel))
 	cfg.DisableLogColor = viper.GetBool(envKeyDisableLogColor)


### PR DESCRIPTION
Adds support for storing and fetching Heresphere HSP files.

To test:
* play a video and seek to some position in Heresphere, open Video Settings, change Orientation sliders, click Orientation key-icon to add a keyframe to the current position, click save-icon at the top, prompt should show the server address, clicking Export should create the .hsp file on the server.
* to reload the API response switch to another video and come back to the previous video, mess with the Orientation again if you like, click download-icon next to save-icon, it should ask if you want to overwrite local settings from the server (for videos that don't have a HSP URL in the API response it'll say something about the local HSP file missing), click Import, click Orientation key-icon, the timestamps should be the ones stored on the server.

(In case anyone wants to run these features before they're merged without compiling their own there's release builds in my GH fork and a build in Docker Hub, just change docker-compose.yml to point to `image: poontology/stash-vr`)