### PR TITLE
change subtitle name from srt -> en.srt

### DIFF
--- a/internal/api/heresphere/videodata.go
+++ b/internal/api/heresphere/videodata.go
@@ -116,7 +116,7 @@ func setSubtitles(vd *library.VideoData, dto *videoDataDto) {
 	}
 	for _, c := range vd.SceneParts.Captions {
 		dto.Subtitles = append(dto.Subtitles, subtitleDto{
-			Name:     c.Caption_type,
+			Name:     fmt.Sprintf("%s.%s", c.Language_code, c.Caption_type),
 			Language: c.Language_code,
 			Url:      stash.ApiKeyed(fmt.Sprintf("%s?lang=%s&type=%s", *vd.SceneParts.Paths.Caption, c.Language_code, c.Caption_type)),
 		})


### PR DESCRIPTION
I saw the `cc` icon in HereSphere turn purple, showing that it recognized there were subtitles, but it wouldn't display them. 

Re-referencing the description of #38: 

>  I found out that if the Name property in stash-vr json reply doesn't end with ".srt" it refused to render subtitles

It seems like the file name was just `srt`, so HereSphere wasn't actually playing the captions. Simplest fix is to just add a preceding `.`, but using the same `{lan}.{type}` like in that PR seems a bit better. 