### PR TITLE
Add Base URL for Reverse Proxy Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,17 @@ services:
     volumes:
       - /path/in/host:/config
     environment:
+      ## URL stash-vr uses to connect to the Stash GraphQL API (server-side, internal).
+      ## This can be the direct container address even when both are behind a reverse proxy.
       STASH_GRAPHQL_URL: "http://localhost:9999/graphql"
+
+      ## Base URL that VR clients use to reach Stash (client-side, public-facing).
+      ## Set this when stash-vr reaches Stash via an internal URL (STASH_GRAPHQL_URL)
+      ## but clients cannot reach that address and must go through a reverse proxy instead.
+      ## All media/stream URLs returned to clients will have their origin rewritten to this value.
+      ## Example: clients connect via https://stash.example.com instead of http://stash:9999
+      #STASH_BASE_URL: "https://stash.example.com"
+
       #STASH_API_KEY: "xxx"
 
       ## For configurations in status page to persist a path must be provided that Stash-VR has write access to.

--- a/internal/api/deovr/videodata.go
+++ b/internal/api/deovr/videodata.go
@@ -42,6 +42,7 @@ type encodingDto struct {
 type videoSourceDto struct {
 	Resolution int    `json:"resolution"`
 	Url        string `json:"url"`
+	Label      string `json:"label,omitempty"`
 }
 
 func buildVideoData(vd *library.VideoData, baseUrl string) (*videoDataDto, error) {
@@ -79,7 +80,7 @@ func buildVideoData(vd *library.VideoData, baseUrl string) (*videoDataDto, error
 }
 
 func setStreamSources(vd *library.VideoData, dto *videoDataDto) {
-	streams := []stash.Stream{stash.GetTranscodingStream(vd.SceneParts), stash.GetDirectStream(vd.SceneParts)}
+	streams := append(stash.GetTranscodingStreams(vd.SceneParts), stash.GetDirectStream(vd.SceneParts))
 	dto.Encodings = make([]encodingDto, len(streams))
 	for i, stream := range streams {
 		dto.Encodings[i] = encodingDto{
@@ -89,7 +90,8 @@ func setStreamSources(vd *library.VideoData, dto *videoDataDto) {
 		for j, source := range stream.Sources {
 			dto.Encodings[i].VideoSources[j] = videoSourceDto{
 				Resolution: source.Resolution,
-				Url:        source.Url,
+				Url:        stash.RebaseUrl(source.Url),
+				Label:      source.Label,
 			}
 		}
 	}

--- a/internal/api/heatmap/heatmap.go
+++ b/internal/api/heatmap/heatmap.go
@@ -75,16 +75,22 @@ func buildHeatmapCover(ctx context.Context, coverUrl string, heatmapUrl string) 
 		return nil
 	})
 
+	err := g.Wait()
+
+	// Drain channels after goroutines have finished.
 	cover := <-chCover
 	heatmap := <-chHeatmap
 
-	err := g.Wait()
 	if err != nil {
 		if errors.Is(err, errScreenshotImageNotFound) {
+			// Cover fetch failed — nothing useful to return.
 			return nil, err
-		} else {
-			return cover, nil
 		}
+		// Heatmap fetch failed — return cover alone if we have it.
+		if cover == nil {
+			return nil, err
+		}
+		return cover, nil
 	}
 
 	heatmapCover := overlay(cover, heatmap)

--- a/internal/api/heatmap/http.go
+++ b/internal/api/heatmap/http.go
@@ -24,7 +24,11 @@ func CoverHandler(libraryService *library.Service) http.HandlerFunc {
 		}
 
 		p := vd.SceneParts.Paths
-		cover, err := buildHeatmapCover(ctx, stash.ApiKeyed(*p.Screenshot), stash.ApiKeyed(*p.Interactive_heatmap))
+		if p.Screenshot == nil || p.Interactive_heatmap == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		cover, err := buildHeatmapCover(ctx, stash.InternalUrl(*p.Screenshot), stash.InternalUrl(*p.Interactive_heatmap))
 		if err != nil {
 			log.Ctx(ctx).Err(err).Msg("buildHeatmapCover")
 			if errors.Is(err, errImageNotFound) {
@@ -32,6 +36,10 @@ func CoverHandler(libraryService *library.Service) http.HandlerFunc {
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)
 			}
+			return
+		}
+		if cover == nil {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		err = jpeg.Encode(w, cover, nil)

--- a/internal/api/heresphere/videodata.go
+++ b/internal/api/heresphere/videodata.go
@@ -50,6 +50,7 @@ type mediaDto struct {
 type sourceDto struct {
 	Resolution int    `json:"resolution,omitempty"`
 	Url        string `json:"url,omitempty"`
+	Label      string `json:"label,omitempty"`
 }
 
 type scriptDto struct {
@@ -206,7 +207,7 @@ func set3DFormat(vd *library.VideoData, dto *videoDataDto) {
 }
 
 func setMediaSources(vd *library.VideoData, dto *videoDataDto) {
-	streams := []stash.Stream{stash.GetDirectStream(vd.SceneParts), stash.GetTranscodingStream(vd.SceneParts)}
+	streams := append([]stash.Stream{stash.GetDirectStream(vd.SceneParts)}, stash.GetTranscodingStreams(vd.SceneParts)...)
 	for _, stream := range streams {
 		e := mediaDto{
 			Name: stream.Name,
@@ -214,7 +215,8 @@ func setMediaSources(vd *library.VideoData, dto *videoDataDto) {
 		for _, s := range stream.Sources {
 			vs := sourceDto{
 				Resolution: s.Resolution,
-				Url:        s.Url,
+				Url:        stash.RebaseUrl(s.Url),
+				Label:      s.Label,
 			}
 			e.Sources = append(e.Sources, vs)
 		}

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -10,6 +10,7 @@ import (
 const (
 	envKeyListenAddress      = "LISTEN_ADDRESS"
 	envKeyStashGraphQLUrl    = "STASH_GRAPHQL_URL"
+	envKeyStashBaseUrl       = "STASH_BASE_URL"
 	envKeyStashApiKey        = "STASH_API_KEY"
 	envKeyFavoriteTag        = "FAVORITE_TAG"
 	envKeyLogLevel           = "LOG_LEVEL"
@@ -25,6 +26,7 @@ const (
 type ApplicationConfig struct {
 	ListenAddress      string
 	StashGraphQLUrl    string
+	StashBaseUrl       string
 	StashApiKey        string
 	FavoriteTag        string
 	LogLevel           string
@@ -45,6 +47,9 @@ func Init() {
 
 	pflag.String(envKeyStashGraphQLUrl, "http://localhost:9999/graphql", "Url to Stash graphql")
 	_ = viper.BindPFlag(envKeyStashGraphQLUrl, pflag.Lookup(envKeyStashGraphQLUrl))
+
+	pflag.String(envKeyStashBaseUrl, "", "Base URL of Stash as reachable by clients (e.g. https://stash.example.com). When set, rewrites the origin of all Stash media URLs returned to clients, overriding the host/port embedded in the GraphQL response. Use this when stash-vr connects to Stash via an internal URL but clients must reach Stash through a reverse proxy.")
+	_ = viper.BindPFlag(envKeyStashBaseUrl, pflag.Lookup(envKeyStashBaseUrl))
 
 	pflag.String(envKeyStashApiKey, "", "Stash API key")
 	_ = viper.BindPFlag(envKeyStashApiKey, pflag.Lookup(envKeyStashApiKey))
@@ -90,6 +95,7 @@ func Init() {
 
 	applicationConfig.ListenAddress = viper.GetString(envKeyListenAddress)
 	applicationConfig.StashGraphQLUrl = viper.GetString(envKeyStashGraphQLUrl)
+	applicationConfig.StashBaseUrl = viper.GetString(envKeyStashBaseUrl)
 	applicationConfig.StashApiKey = viper.GetString(envKeyStashApiKey)
 	applicationConfig.FavoriteTag = viper.GetString(envKeyFavoriteTag)
 	applicationConfig.LogLevel = strings.ToLower(viper.GetString(envKeyLogLevel))

--- a/internal/library/scenes.go
+++ b/internal/library/scenes.go
@@ -28,9 +28,22 @@ func (libraryService *Service) GetScenes(ctx context.Context) (map[string]*Video
 				return nil, err
 			}
 
+			// Build a set of IDs that came back with data.
+			returned := make(map[string]struct{}, len(vds))
+			for _, vd := range vds {
+				returned[vd.Id()] = struct{}{}
+			}
+
 			libraryService.muVdCache.Lock()
 			for _, vd := range vds {
 				libraryService.vdCache[vd.Id()] = vd
+			}
+			// Remove nil sentinels for scenes that were fetched but had no files.
+			for _, id := range toFetch {
+				key := strconv.Itoa(id)
+				if _, ok := returned[key]; !ok {
+					delete(libraryService.vdCache, key)
+				}
 			}
 			libraryService.muVdCache.Unlock()
 			elapsed := time.Since(start)
@@ -61,6 +74,9 @@ func (libraryService *Service) GetScene(ctx context.Context, id string, forceFet
 	if err != nil {
 		return nil, err
 	}
+	if len(vds) == 0 {
+		return nil, fmt.Errorf("scene %s not found or has no files", id)
+	}
 
 	libraryService.muVdCache.Lock()
 	libraryService.vdCache[id] = vds[0]
@@ -74,11 +90,15 @@ func (libraryService *Service) fetchVideoData(ctx context.Context, sceneIds []in
 	if err != nil {
 		return nil, fmt.Errorf("FindScenes: %w", err)
 	}
-	vds := make([]*VideoData, len(resp.FindScenes.Scenes))
-	for i, s := range resp.FindScenes.Scenes {
+	vds := make([]*VideoData, 0, len(resp.FindScenes.Scenes))
+	for _, s := range resp.FindScenes.Scenes {
+		if len(s.SceneParts.Files) == 0 {
+			log.Ctx(ctx).Trace().Str("id", s.SceneParts.Id).Msg("Skipping scene with no files")
+			continue
+		}
 		vd := VideoData{SceneParts: &s.SceneParts}
 		libraryService.decorateTags(&vd)
-		vds[i] = &vd
+		vds = append(vds, &vd)
 	}
 	return vds, nil
 }

--- a/internal/stash/apikey.go
+++ b/internal/stash/apikey.go
@@ -1,18 +1,51 @@
 package stash
 
 import (
+	"net/url"
 	"stash-vr/internal/config"
 	"strings"
 )
 
-func ApiKeyed(url string) string {
-	apiKey := config.Application().StashApiKey
-	if apiKey == "" || strings.Contains(url, "apikey") {
-		return url
-	}
-	if strings.Contains(url, "?") {
-		return url + "&apikey=" + apiKey
+// RebaseUrl replaces the scheme, host, and port of a Stash-origin URL with
+// the base URL configured via STASH_BASE_URL. This allows the server to
+// connect to Stash internally while directing clients to the public-facing
+// reverse proxy address. If STASH_BASE_URL is not set the original URL is
+// returned unchanged.
+func RebaseUrl(rawUrl string) string {
+	stashBaseUrl := config.Application().StashBaseUrl
+	if stashBaseUrl == "" {
+		return rawUrl
 	}
 
-	return url + "?apikey=" + apiKey
+	parsed, err := url.Parse(rawUrl)
+	if err != nil {
+		return rawUrl
+	}
+
+	base, err := url.Parse(stashBaseUrl)
+	if err != nil {
+		return rawUrl
+	}
+
+	parsed.Scheme = base.Scheme
+	parsed.Host = base.Host
+
+	return parsed.String()
+}
+
+// ApiKeyed appends the configured Stash API key to the URL as a query
+// parameter. The URL origin is first rewritten via RebaseUrl if STASH_BASE_URL
+// is configured.
+func ApiKeyed(rawUrl string) string {
+	u := RebaseUrl(rawUrl)
+
+	apiKey := config.Application().StashApiKey
+	if apiKey == "" || strings.Contains(u, "apikey") {
+		return u
+	}
+	if strings.Contains(u, "?") {
+		return u + "&apikey=" + apiKey
+	}
+
+	return u + "?apikey=" + apiKey
 }

--- a/internal/stash/apikey.go
+++ b/internal/stash/apikey.go
@@ -35,7 +35,7 @@ func RebaseUrl(rawUrl string) string {
 
 // ApiKeyed appends the configured Stash API key to the URL as a query
 // parameter. The URL origin is first rewritten via RebaseUrl if STASH_BASE_URL
-// is configured.
+// is configured. Use this for URLs that will be sent to clients.
 func ApiKeyed(rawUrl string) string {
 	u := RebaseUrl(rawUrl)
 
@@ -48,4 +48,20 @@ func ApiKeyed(rawUrl string) string {
 	}
 
 	return u + "?apikey=" + apiKey
+}
+
+// InternalUrl appends the configured Stash API key to the URL as a query
+// parameter WITHOUT rebasing to STASH_BASE_URL. Use this for server-side
+// fetches made by stash-vr itself (e.g. fetching images to composite),
+// where the public-facing URL may not be reachable from inside the container.
+func InternalUrl(rawUrl string) string {
+	apiKey := config.Application().StashApiKey
+	if apiKey == "" || strings.Contains(rawUrl, "apikey") {
+		return rawUrl
+	}
+	if strings.Contains(rawUrl, "?") {
+		return rawUrl + "&apikey=" + apiKey
+	}
+
+	return rawUrl + "?apikey=" + apiKey
 }

--- a/internal/stash/stream.go
+++ b/internal/stash/stream.go
@@ -17,14 +17,18 @@ type Stream struct {
 type Source struct {
 	Resolution int
 	Url        string
+	Label      string
 }
 
 var rgxResolution = regexp.MustCompile(`\((\d+)p\)`)
+var rgxContainer = regexp.MustCompile(`\((MP4|WebM|HLS|DASH)\)`)
 
 func GetDirectStream(sp *gql.SceneParts) Stream {
+	res := sp.Files[0].Height
 	directStream := Source{
-		Resolution: sp.Files[0].Height,
+		Resolution: res,
 		Url:        *sp.Paths.Stream,
+		Label:      fmt.Sprintf("Direct-%dp", res),
 	}
 
 	return Stream{
@@ -32,31 +36,79 @@ func GetDirectStream(sp *gql.SceneParts) Stream {
 		Sources: []Source{directStream},
 	}
 }
-func GetTranscodingStream(sp *gql.SceneParts) Stream {
-	mp4Sources := make([]Source, 0)
-	seenResolutions := make(map[int]struct{})
-	for _, stream := range sp.SceneStreams {
-		if strings.HasPrefix(*stream.Mime_type, "video/mp4") && *stream.Label != "Direct stream" {
-			resolution, err := parseResolutionFromLabel(*stream.Label)
-			if err != nil {
-				resolution = sp.Files[0].Height
-			}
-			if _, seen := seenResolutions[resolution]; seen {
-				continue
-			}
-			mp4Sources = append(mp4Sources, Source{
-				Resolution: resolution,
-				Url:        stream.Url,
-			})
-			seenResolutions[resolution] = struct{}{}
-		}
-	}
-	slices.SortFunc(mp4Sources, func(a, b Source) int { return b.Resolution - a.Resolution })
 
-	return Stream{
-		Name:    "transcoding",
-		Sources: mp4Sources,
+func GetTranscodingStreams(sp *gql.SceneParts) []Stream {
+	streamsByType := make(map[string][]Source)
+
+	for _, stream := range sp.SceneStreams {
+		label := ""
+		if stream.Label != nil {
+			label = *stream.Label
+		}
+		if label == "Direct stream" {
+			continue
+		}
+
+		resolution, err := parseResolutionFromLabel(label)
+		if err != nil {
+			resolution = sp.Files[0].Height
+		}
+
+		mimeType := ""
+		if stream.Mime_type != nil {
+			mimeType = *stream.Mime_type
+		}
+
+		container := parseContainerFromLabel(label)
+		isDash := mimeType == "application/dash+xml" || strings.Contains(strings.ToUpper(label), "DASH")
+		isMP4 := strings.Contains(strings.ToUpper(label), "MP4")
+
+		if !isDash && !isMP4 {
+			continue
+		}
+
+		// If matched by characteristics but not label regex, set container
+		if container == "" {
+			if isDash {
+				container = "DASH"
+			} else if isMP4 {
+				container = "MP4"
+			}
+		}
+
+		sourceLabel := fmt.Sprintf("%dp", resolution)
+		if container != "" {
+			sourceLabel = fmt.Sprintf("%s-%dp", container, resolution)
+		}
+
+		streamsByType[container] = append(streamsByType[container], Source{
+			Resolution: resolution,
+			Url:        stream.Url,
+			Label:      sourceLabel,
+		})
 	}
+
+	res := make([]Stream, 0, len(streamsByType))
+	for container, sources := range streamsByType {
+		slices.SortFunc(sources, func(a, b Source) int { return b.Resolution - a.Resolution })
+		name := "transcoding"
+		if container != "" {
+			name = fmt.Sprintf("transcoding (%s)", container)
+		}
+		res = append(res, Stream{
+			Name:    name,
+			Sources: sources,
+		})
+	}
+
+	slices.SortFunc(res, func(a, b Stream) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		return 1
+	})
+
+	return res
 }
 
 func parseResolutionFromLabel(label string) (int, error) {
@@ -69,4 +121,12 @@ func parseResolutionFromLabel(label string) (int, error) {
 		return 0, fmt.Errorf("atoi: %w", err)
 	}
 	return res, nil
+}
+
+func parseContainerFromLabel(label string) string {
+	match := rgxContainer.FindStringSubmatch(label)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
 }


### PR DESCRIPTION
- Add a STASH_BASE_URL option so that media URLs returned to VR clients are rewritten to a public-facing address, even when stash-vr connects to Stash internally using a different Docker host/IP.

- Splits available transcoding streams by container type (MP4, DASH, etc.) and adds labels.